### PR TITLE
[container] rename docker to container in site.yml

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -7,7 +7,7 @@
     # - baseline
     # - bitwarden
     # - caddy
-    # - docker
+    # - container
     # - duo
     # - firewalld
     # - grafana


### PR DESCRIPTION
* missed this reference when migrating from docker to podman
